### PR TITLE
Make Printer::ESCPOS installable again

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -16,7 +16,8 @@
 	"build-depends" : [],
 	"depends" : [],
 	"test-depends" : [
-		"Test"
+		"Test",
+		"Test::META"
 	],
 	"provides" : {
 		"Printer::ESCPOS" : "lib/Printer/ESCPOS.pm6",

--- a/META6.json
+++ b/META6.json
@@ -33,5 +33,5 @@
 	  "EPSON"
 	],
 	"resources" : [  ],
-	"license" : "Artistic"
+	"license" : "Artistic-2.0"
 }


### PR DESCRIPTION
Just some tiny META6.json issue.